### PR TITLE
fix: template draw order

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -165,7 +165,7 @@ export default class Generator {
             size: spriteData.size
         }
 
-        this.drawTemplate(outfitData, addonSpriteData);
+        await this.drawTemplate(outfitData, addonSpriteData);
     }
 
     /**


### PR DESCRIPTION
Fixes the template draw order by adding a missing await to the `drawTemplate` method